### PR TITLE
use C++ instead of C for maximum compatibilty; depend on new version …

### DIFF
--- a/module.json
+++ b/module.json
@@ -19,7 +19,7 @@
     }
   ],
   "dependencies": {
-    "simplelog": "~0.0.0"
+    "simplelog": "^1.0.0"
   },
   "targetDependencies": {
     "mbed": {

--- a/source/hello.cpp
+++ b/source/hello.cpp
@@ -26,7 +26,7 @@ void app_start(int argc, char *argv[]) {
 // app-start as the entry point (see https://github.com/ARMmbed/mbed-drivers)
 #ifndef TARGET_LIKE_MBED
 int main(){
-    app_start(0, (void*)0);
+    app_start(0, (char**)0);
     return 0;
 }
 #endif


### PR DESCRIPTION
…of simpleLog which correctly extern-Cs its declarations.

Fixes #4, when @salkinium files it.